### PR TITLE
Allow resetting the sort order to an empty array

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -198,6 +198,18 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
     }
 
     /**
+     * Reset the sort order.
+     *
+     * @return self
+     */
+    public function resetOrder()
+    {
+        $this->_orders = [];
+
+        return $this;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function addFieldToFilter($field, $condition = null)


### PR DESCRIPTION
In a normal Magento collection you would do something like this:

`$collection->getSelect()->reset(Zend_Db_Select::ORDER);`

However, this obviously wouldn't work for elasticsuite.